### PR TITLE
fix: update script to exec go mod tidy

### DIFF
--- a/generic-update-script.rb
+++ b/generic-update-script.rb
@@ -27,6 +27,12 @@ directory = ENV["DIRECTORY_PATH"] || "/"
 # Branch to look at. Defaults to repo's default branch
 branch = ENV["BRANCH"]
 
+# For go modules.
+repo_contents_path = ENV["REPO_CONTENTS_PATH"] || "/contents"
+
+# Comma separated dependency names.
+dependency_names = (ENV["DEPENDENCIES"] || "").split(",")
+
 # Name of the package manager you'd like to do the update for. Options are:
 # - bundler
 # - pip (includes pipenv)
@@ -165,7 +171,7 @@ parser = Dependabot::FileParsers.for_package_manager(package_manager).new(
 )
 
 dependencies = parser.parse
-
+dependencies = dependencies.select { |d| dependency_names.include?(d.name) } if dependency_names.size > 0
 dependencies.select(&:top_level?).each do |dep|
   #########################################
   # Get update details for the dependency #
@@ -202,6 +208,7 @@ dependencies.select(&:top_level?).each do |dep|
     dependencies: updated_deps,
     dependency_files: files,
     credentials: credentials,
+    repo_contents_path: repo_contents_path,
   )
 
   updated_files = updater.updated_dependency_files

--- a/generic-update-script.rb
+++ b/generic-update-script.rb
@@ -225,7 +225,7 @@ dependencies.select(&:top_level?).each do |dep|
     files: updated_files,
     credentials: credentials,
     assignees: assignees,
-    author_details: { name: "Dependabot", email: "no-reply@github.com" },
+    author_details: { name: "dependabot[bot]", email: "49699333+dependabot[bot]@users.noreply.github.com" },
     label_language: true,
   )
   pull_request = pr_creator.create


### PR DESCRIPTION
- `go mod tidy` を実行するために必要な `repo_contents_path` を追加。
- `DEPENDENCIES` 環境変数により、一部の依存 module だけの更新に対応。

## Example
```
docker run --rm -v $(pwd):/contents -e "PACKAGE_MANAGER=go_modules" -e "PROJECT_PATH=ww24/calendar-notifier" -e "DEPENDENCIES=google.golang.org/grpc,cloud.google.com/go/pubsub" -e "GITHUB_ACCESS_TOKEN=$GITHUB_TOKEN" dependabot/dependabot-script
```